### PR TITLE
refactor: `Board.getBoardsList`의 입력 데이터를 DTO로 변경

### DIFF
--- a/src/modules/board/board.controller.ts
+++ b/src/modules/board/board.controller.ts
@@ -5,6 +5,7 @@ import { RoleGuard } from '../auth/guards/role.guard';
 import { UserRoles } from '../auth/types/role.decorator';
 import { Role } from '../auth/types/role.enum';
 import { BoardService } from './board.service';
+import { BoardListReqDto } from './dto/req/board.list.req.dto';
 import { BoardReqDto } from './dto/req/board.req.dto';
 import { BoardDetailResDto } from './dto/res/board.detail.res.dto';
 import { BoardListResDto } from './dto/res/board.list.res.dto';
@@ -23,10 +24,10 @@ export class BoardController {
 	async getBoardsList(
 		@Query('page') page: number,
 		@Query('pageSize') pageSize: number,
-		@Query('category') category: string,
-		@Query('title') title: string,
+		@Query() boardsListReqDto: BoardListReqDto,
 		@Req() req: Request,
 	): Promise<BoardListResDto> {
+		const { category, title } = boardsListReqDto;
 		return this.boardService.getAllBoards(page, pageSize, category, title, req);
 	}
 

--- a/src/modules/board/dto/req/board.list.req.dto.ts
+++ b/src/modules/board/dto/req/board.list.req.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class BoardListReqDto {
+	@IsString()
+	@IsOptional()
+	@ApiProperty({ description: '공지사항 카테고리 별 검색 단어', required: false })
+	public readonly category: string;
+
+	@IsString()
+	@IsOptional()
+	@ApiProperty({ description: '공지사항 제목 별 검색 단어', required: false })
+	public readonly title: string;
+}


### PR DESCRIPTION
- 서버 - 사용자 간 통신에서 DTO를 활용하는 것을 메인으로 한다.
- `category` 및 `title`에 `required` 속성을 제외하고 필요에 따라 입력하도록 수정