### PR TITLE
feat: `Login` 성공 시 사용자에 대한 정보 전달

### DIFF
--- a/src/modules/user/dto/res/user.login.res.dto.ts
+++ b/src/modules/user/dto/res/user.login.res.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsNumber, IsObject, IsString } from 'class-validator';
+
+export class UserLoginResDto {
+	@IsString()
+	@IsNotEmpty()
+	@ApiProperty({ description: '회사명' })
+	company_name: string;
+
+	@IsString()
+	@IsNotEmpty()
+	@ApiProperty({ description: '아이디' })
+	user_id: string;
+
+	@IsString()
+	@IsNotEmpty()
+	@ApiProperty({ description: '담당자명' })
+	manager_name: string;
+
+	@IsNumber()
+	@IsNotEmpty()
+	@ApiProperty({ description: '캐시' })
+	cash: number;
+
+	@IsNumber()
+	@IsNotEmpty()
+	@ApiProperty({ description: '포인트' })
+	point: number;
+
+	@IsString()
+	@IsNotEmpty()
+	@ApiProperty({ description: '역할' })
+	role: string;
+
+	@IsObject()
+	@IsNotEmpty()
+	@ApiProperty({ description: '토큰 정보' })
+	token: {
+		accessToken: string;
+		refreshToken: string;
+	};
+}

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -9,6 +9,7 @@ import { SignUpReqDto } from './dto/req/signup.req.dto';
 import { UserDetailReqDto } from './dto/req/user.detail.req.dto';
 import { SignUpResDto } from './dto/res/signup.res.dto';
 import { UserDetailResDto } from './dto/res/user.detail.res.dto';
+import { UserLoginResDto } from './dto/res/user.login.res.dto';
 import { UserService } from './user.service';
 
 @ApiTags('User')
@@ -26,13 +27,24 @@ export class UserController {
 
 	// 로그인
 	@Post('login')
-	@ApiResponse({ type: SignUpResDto })
+	@ApiResponse({ type: UserLoginResDto })
 	@UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }))
 	async login(@Body() user: LoginReqDto, @Req() req: any, @Res() res: Response) {
-		const { accessToken, refreshToken } = await this.userService.login(user, req);
-		res.cookie('access_token', accessToken);
-		res.cookie('refresh_token', refreshToken);
-		return res.json({ accessToken, refreshToken });
+		const { company_name, user_id, manager_name, cash, point, role, token } = await this.userService.login(user, req);
+		res.cookie('access_token', token.accessToken);
+		res.cookie('refresh_token', token.refreshToken);
+		return res.json({
+			company_name,
+			user_id,
+			manager_name,
+			cash,
+			point,
+			role,
+			token: {
+				accessToken: token.accessToken,
+				refreshToken: token.refreshToken,
+			},
+		});
 	}
 
 	@Post('logout')
@@ -81,7 +93,7 @@ export class UserController {
 	async findUserPassword(@Res() res: Response, @Body() findUserDataReqDto: FindUserDataReqDto) {
 		// 성공 시 해당 사용자 데이터에 임시 접근 가능한 token을 발급해서 처리?
 		const { resetToken } = await this.userService.findUserPassword(findUserDataReqDto);
-		res.cookie('reset_token', resetToken, { httpOnly: true });
+		res.cookie('reset_token', resetToken);
 		return res.json({ resetToken: resetToken });
 	}
 

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -31,6 +31,7 @@ import { SignUpReqDto } from './dto/req/signup.req.dto';
 import { UserDetailReqDto } from './dto/req/user.detail.req.dto';
 import { SignUpResDto } from './dto/res/signup.res.dto';
 import { UserDetailResDto } from './dto/res/user.detail.res.dto';
+import { UserLoginResDto } from './dto/res/user.login.res.dto';
 import { LoginLog } from './schemas/login-log.schema';
 import { User } from './schemas/user.schema';
 
@@ -97,7 +98,7 @@ export class UserService {
 	}
 
 	// 로그인
-	async login(user: LoginReqDto, @Req() req: any): Promise<{ accessToken: string; refreshToken: string }> {
+	async login(user: LoginReqDto, @Req() req: any): Promise<UserLoginResDto> {
 		const userId = user.user_id;
 		const password = user.password;
 
@@ -147,7 +148,15 @@ export class UserService {
 
 			const refreshToken = this.authService.createToken({ userId: userId }, 'refresh');
 
-			return { accessToken, refreshToken };
+			return {
+				company_name: existedUser.company_name,
+				user_id: existedUser.user_id,
+				manager_name: existedUser.manager_name,
+				cash: existedUser.cash,
+				point: existedUser.point,
+				role: existedUser.role,
+				token: { accessToken, refreshToken },
+			};
 		} catch (error) {
 			throw error;
 		}


### PR DESCRIPTION
- 로그인 성공 시 `Token` 데이터 이외에 다른 사용자 데이터가 포함되었으면 한다는 요청에 의해 작업
- `회사명`, `회원 아이디`, `담당자명`, `보유 캐시`, `보유 포인트`, `사용자 역할` 데이터를 포함해서 전달
- API 실행 결과 전달하면서 전역 `Cookie` 설정 덮어씌우던 부분 제거